### PR TITLE
Replace `.GetAssayData()` with `SeuratObject::GetAssayData()`

### DIFF
--- a/R/do_AffinityAnalysisPlot.R
+++ b/R/do_AffinityAnalysisPlot.R
@@ -1,12 +1,12 @@
 #' Compute affinity of gene sets to cell populations using decoupleR.
 #'
-#' Major contributions to this function: 
+#' Major contributions to this function:
 #' - \href{https://github.com/MarcElosua}{Marc Elosua Bayés} for the core concept code and idea.
 #' - \href{https://github.com/paubadiam}{Pau Badia i Mompel} for the network generation.
-#' 
+#'
 #' @inheritParams doc_function
 #' @param statistic \strong{\code{\link[base]{character}}} | DecoupleR statistic to use for the analysis.
-#' values in the Idents of the Seurat object are reported, assessing how specific a given gene set is for a given cell population compared to other gene sets of equal expression. 
+#' values in the Idents of the Seurat object are reported, assessing how specific a given gene set is for a given cell population compared to other gene sets of equal expression.
 #'
 #' @return A list containing different plots.
 #' @export
@@ -61,14 +61,14 @@ do_AffinityAnalysisPlot <- function(sample,
                                     legend.text.face = "plain"){
   # Add lengthy error messages.
   withr::local_options(.new = list("warning.length" = 8170))
-  
+
   check_suggests("do_AffinityAnalysisPlot")
-  
+
   check_Seurat(sample)
-  
+
   if (is.null(assay)){assay <- check_and_set_assay(sample)$assay}
   if (is.null(slot)){slot <- check_and_set_slot(slot)}
-  
+
   # Check logical parameters.
   logical_list <- list("verbose" = verbose,
                        "flip" = flip,
@@ -117,15 +117,15 @@ do_AffinityAnalysisPlot <- function(sample,
                          "legend.text.face" = legend.text.face,
                          "na.value" = na.value)
   check_type(parameters = character_list, required_type = "character", test_function = is.character)
-  
+
   `%>%` <- magrittr::`%>%`
-  
+
   check_colors(grid.color, parameter_name = "grid.color")
   check_colors(na.value, parameter_name = "na.value")
   check_colors(border.color, parameter_name = "border.color")
   check_colors(legend.tickcolor, parameter_name = "legend.tickcolor")
   check_colors(legend.framecolor, parameter_name = "legend.framecolor")
-  
+
   check_parameters(parameter = font.type, parameter_name = "font.type")
   check_parameters(parameter = legend.position, parameter_name = "legend.position")
   check_parameters(plot.title.face, parameter_name = "plot.title.face")
@@ -138,18 +138,18 @@ do_AffinityAnalysisPlot <- function(sample,
   check_parameters(viridis.direction, parameter_name = "viridis.direction")
   check_parameters(sequential.direction, parameter_name = "sequential.direction")
   check_parameters(diverging.direction, parameter_name = "diverging.direction")
-  
+
   # Assign a group.by if this is null.
   out <- check_group_by(sample = sample,
                         group.by = group.by,
                         is.heatmap = TRUE)
   sample <- out[["sample"]]
   group.by <- out[["group.by"]]
-  
+
   if (!is.na(subsample)){
     sample <- sample[, sample(colnames(sample), subsample)]
   }
-  
+
   # Generate the continuous color palette.
   if (isTRUE(enforce_symmetry)){
     colors.gradient <- compute_continuous_palette(name = diverging.palette,
@@ -162,8 +162,8 @@ do_AffinityAnalysisPlot <- function(sample,
                                                   direction = ifelse(isTRUE(use_viridis), viridis.direction, sequential.direction),
                                                   enforce_symmetry = enforce_symmetry)
   }
-  
-  
+
+
   # Generate a network with the names of the list of genes as source and the gene sets as targets with 1 of mode of regulation.
   # Step 1: Check for underscores in the names of the gene sets.
   if (length(unlist(stringr::str_match_all(names(input_gene_list), "_"))) > 0){
@@ -175,27 +175,27 @@ do_AffinityAnalysisPlot <- function(sample,
     names.use <- stringr::str_replace_all(names(input_gene_list), "_", ".")
     names(input_gene_list) <- names.use
   }
-  
+
   # Step 2: make the lists of equal length.
   max_value <- max(unname(unlist(lapply(input_gene_list, length))))
   min_value <- min(unname(unlist(lapply(input_gene_list, length))))
-  
+
   assertthat::assert_that(length(input_gene_list) >= 2,
-                          msg = paste0(add_cross, 
+                          msg = paste0(add_cross,
                                        crayon_body("Please make sure that the gene list you provide to "),
                                        crayon_key("input_gene_list"),
                                        crayon_body(" have at least "),
                                        crayon_key("two different"),
                                        crayon_body(" gene sets.")))
-  
+
   assertthat::assert_that(min_value >= 5,
-                          msg = paste0(add_cross, 
+                          msg = paste0(add_cross,
                                        crayon_body("Please make sure that the gene list you provide to "),
                                        crayon_key("input_gene_list"),
                                        crayon_body(" have at least "),
                                        crayon_key("five genes"),
                                        crayon_body(" each.")))
-  
+
   # Add fake genes until all lists have the same length so that it can be converted into a tibble.
   gene_list <- lapply(input_gene_list, function(x){
     if (length(x) != max_value){
@@ -206,96 +206,96 @@ do_AffinityAnalysisPlot <- function(sample,
       x
     }
   })
-  
+
   # Generate the network as a tibble and filter out fake genes.
-  network <- gene_list %>% 
-             tibble::as_tibble() %>% 
+  network <- gene_list %>%
+             tibble::as_tibble() %>%
              tidyr::pivot_longer(cols = dplyr::everything(),
                                  names_to = "source",
-                                 values_to = "target") %>% 
-             dplyr::mutate("mor" = 1) %>% 
+                                 values_to = "target") %>%
+             dplyr::mutate("mor" = 1) %>%
              dplyr::filter(.data$target != "deleteme")
-  
+
   # Get expression data.
-  mat <- .GetAssayData(sample,
+  mat <- SeuratObject::GetAssayData(sample,
                       assay = assay,
                       slot = slot)
-  
+
   # Compute activities.
   if(isTRUE(verbose)){message(paste0(add_info(), crayon_body("Computing "),
                                      crayon_key("activities"),
                                      crayon_body("...")))}
-  
-  acts <- decoupleR::run_wmean(mat = mat, 
+
+  acts <- decoupleR::run_wmean(mat = mat,
                                network = network)
-  
+
   # Turn them into a matrix compatible to turn into a Seurat assay.
-  acts.matrix <- acts %>% 
-                 dplyr::filter(.data$statistic == .env$statistic) %>% 
+  acts.matrix <- acts %>%
+                 dplyr::filter(.data$statistic == .env$statistic) %>%
                  tidyr::pivot_wider(id_cols = dplyr::all_of("source"),
                                     names_from = "condition",
                                     values_from = "score") %>%
                  tibble::column_to_rownames('source')
-  
+
   # Generate a Seurat assay.
   assay.add <- Seurat::CreateAssayObject(acts.matrix)
-  
+
   # Add the assay to the Seurat object.
   sample@assays$affinity <- assay.add
   sample@assays$affinity@key <- "affinity_"
-  
+
   # Set it as default assay.
   Seurat::DefaultAssay(sample) <- "affinity"
-  
+
   # Scale and center the activity data.
   sample <- Seurat::ScaleData(sample, verbose = FALSE, assay = "affinity")
-  
+
   # Plotting.
   # Get the data frames per group.by value for plotting.
   list.data <- list()
   counter <- 0
   for (group in group.by){
     counter <- counter + 1
-    data.use <- .GetAssayData(sample, 
-                             assay = "affinity", 
-                             slot = "scale.data") %>% 
-                t() %>% 
-                as.data.frame() %>% 
-                tibble::rownames_to_column(var = "cell") %>% 
-                dplyr::left_join(y = {sample@meta.data %>% 
-                                      tibble::rownames_to_column(var = "cell") %>% 
+    data.use <- SeuratObject::GetAssayData(sample,
+                             assay = "affinity",
+                             slot = "scale.data") %>%
+                t() %>%
+                as.data.frame() %>%
+                tibble::rownames_to_column(var = "cell") %>%
+                dplyr::left_join(y = {sample@meta.data %>%
+                                      tibble::rownames_to_column(var = "cell") %>%
                                       dplyr::select(dplyr::all_of(c("cell", group)))},
-                                      by = "cell") %>% 
+                                      by = "cell") %>%
                 tidyr::pivot_longer(cols = -dplyr::all_of(c("cell", group)),
                                     names_to = "source",
                                     values_to = "score")
-    
+
     # Clustering based on the median across all cells.
-    data.cluster <- data.use %>% 
+    data.cluster <- data.use %>%
                     tidyr::pivot_wider(id_cols = dplyr::all_of(c("cell", group)),
                                        names_from = "source",
-                                       values_from = "score") %>% 
-                    dplyr::group_by(.data[[group]]) %>% 
+                                       values_from = "score") %>%
+                    dplyr::group_by(.data[[group]]) %>%
                     dplyr::summarise(dplyr::across(.cols = dplyr::all_of(c(names(input_gene_list))),
-                                                   function(x){stats::median(x, na.rm = TRUE)})) %>% 
-                    as.data.frame() %>% 
-                    tibble::column_to_rownames(var = group) 
-    
+                                                   function(x){stats::median(x, na.rm = TRUE)})) %>%
+                    as.data.frame() %>%
+                    tibble::column_to_rownames(var = group)
+
     list.data[[group]][["data"]] <- data.use
     list.data[[group]][["data.cluster"]] <- data.cluster
   }
-  
+
   # Plot individual heatmaps.
-  
+
   list.heatmaps <- list()
   counter <- 0
   row.order.list <- list()
   for (group in group.by){
     counter <- counter + 1
-    
+
     data.use <- list.data[[group]][["data"]]
     data.cluster <- list.data[[group]][["data.cluster"]]
-    
+
     # nocov start
     if (counter == 1){
       if (length(colnames(data.cluster)) == 1){
@@ -305,32 +305,32 @@ do_AffinityAnalysisPlot <- function(sample,
       }
     }
     # nocov end
-    
+
     if(length(rownames(data.cluster)) == 1){
       row_order <- rownames(data.cluster)[1]
     } else {
       row_order <- rownames(data.cluster)[stats::hclust(stats::dist(data.cluster, method = "euclidean"), method = "ward.D")$order]
     }
     row.order.list[[group]] <- row_order
-    
-    data.use <- data.use %>% 
-                dplyr::group_by(.data[[group]], .data$source) %>% 
+
+    data.use <- data.use %>%
+                dplyr::group_by(.data[[group]], .data$source) %>%
                 dplyr::summarise("mean" = mean(.data$score, na.rm = TRUE))
-    
+
     list.data[[group]][["data.mean"]] <- data.use
-    
+
     if (!is.na(min.cutoff)){
       data.use <- data.use %>%
                   dplyr::mutate("mean" = ifelse(.data$mean < min.cutoff, min.cutoff, .data$mean))
     }
-    
+
     if (!is.na(max.cutoff)){
       data.use <- data.use %>%
                   dplyr::mutate("mean" = ifelse(.data$mean > max.cutoff, max.cutoff, .data$mean))
     }
-    p <- data.use %>% 
+    p <- data.use %>%
          dplyr::mutate("source" = factor(.data$source, levels = col_order),
-                       "target" = factor(.data[[group]], levels = row_order)) %>% 
+                       "target" = factor(.data[[group]], levels = row_order)) %>%
          # nocov start
          ggplot2::ggplot(mapping = ggplot2::aes(x = if (isTRUE(flip)){.data$source} else {.data$target},
                                                 y = if (isTRUE(flip)){.data$target} else {.data$source},
@@ -342,28 +342,28 @@ do_AffinityAnalysisPlot <- function(sample,
                                    position = "top") +
          # nocov start
          ggplot2::guides(y.sec = guide_axis_label_trans(~paste0(levels(if (isTRUE(flip)){.data$target} else {.data$source}))),
-                         x.sec = guide_axis_label_trans(~paste0(levels(if (isTRUE(flip)){.data$source} else {.data$target})))) + 
+                         x.sec = guide_axis_label_trans(~paste0(levels(if (isTRUE(flip)){.data$source} else {.data$target})))) +
          # nocov end
-         ggplot2::coord_equal() 
+         ggplot2::coord_equal()
     list.heatmaps[[group]] <- p
   }
-  
-  
+
+
   # Compute limits.
   min.vector <- NULL
   max.vector <- NULL
-  
+
   for (group in group.by){
     data.limits <-  list.data[[group]][["data.mean"]]
-    
+
     min.vector <- append(min.vector, min(data.limits$mean, na.rm = TRUE))
     max.vector <- append(max.vector, max(data.limits$mean, na.rm = TRUE))
   }
-  
+
   # Get the absolute limits of the datasets.
   limits <- c(min(min.vector, na.rm = TRUE),
               max(max.vector, na.rm = TRUE))
-  
+
   # Compute overarching scales for all heatmaps.
   scale.setup <- compute_scales(sample = sample,
                                 feature = " ",
@@ -377,25 +377,25 @@ do_AffinityAnalysisPlot <- function(sample,
                                 enforce_symmetry = enforce_symmetry,
                                 from_data = TRUE,
                                 limits.use = limits)
-  
+
   for (group in group.by){
     p <- list.heatmaps[[group]]
-    
-    p <- p + 
+
+    p <- p +
          ggplot2::scale_fill_gradientn(colors = colors.gradient,
                                        na.value = na.value,
                                        name = paste0(statistic, " | Scaled and Centered"),
                                        breaks = scale.setup$breaks,
                                        labels = scale.setup$labels,
                                        limits = scale.setup$limits)
-    
+
     list.heatmaps[[group]] <- p
   }
-  
+
   # Modify legends.
   for (group in group.by){
     p <- list.heatmaps[[group]]
-    
+
     p <- modify_continuous_legend(p = p,
                                   legend.aes = "fill",
                                   legend.type = legend.type,
@@ -408,14 +408,14 @@ do_AffinityAnalysisPlot <- function(sample,
                                   legend.tickwidth = legend.tickwidth)
     list.heatmaps[[group]] <- p
   }
-  
+
   # Add theme
   counter <- 0
   for (group in group.by){
     counter <- counter + 1
-    
+
     p <- list.heatmaps[[group]]
-    
+
     # Set axis titles.
     if (isTRUE(flip)){
       if (counter == 1){
@@ -437,10 +437,10 @@ do_AffinityAnalysisPlot <- function(sample,
         xlab <- group
       }
     }
-    
-    
+
+
     p <- list.heatmaps[[group]]
-    
+
     axis.parameters <- handle_axis(flip = !flip,
                                    group.by = rep("A", length(group.by)),
                                    group = group,
@@ -453,7 +453,7 @@ do_AffinityAnalysisPlot <- function(sample,
                                    axis.text.face = axis.text.face,
                                    legend.title.face = legend.title.face,
                                    legend.text.face = legend.text.face)
-    
+
     p <- p +
          ggplot2::xlab(xlab) +
          ggplot2::ylab(ylab) +
@@ -493,10 +493,10 @@ do_AffinityAnalysisPlot <- function(sample,
                         panel.background = ggplot2::element_rect(fill = "white", color = "white"),
                         legend.background = ggplot2::element_rect(fill = "white", color = "white"),
                         panel.spacing.x = ggplot2::unit(0, "cm"))
-    
+
     list.heatmaps[[group]] <- p
   }
-  
+
 
   if (isTRUE(flip)){
     list.heatmaps <- list.heatmaps[rev(group.by)]
@@ -518,21 +518,21 @@ do_AffinityAnalysisPlot <- function(sample,
                                                                                               color = "black",
                                                                                               hjust = 1),
                                                          plot.caption.position = "plot"))
-  
+
   list.output <- list()
-  
+
   list.output[["Heatmap"]] <- p
-  
-  
+
+
   if (isTRUE(return_object)){
     list.output[["Object"]] <- sample
   }
-  
+
   if (isTRUE(return_object)){
     return_me <- list.output
   } else {
     return_me <- list.output$Heatmap
   }
-  
+
   return(return_me)
 }

--- a/R/do_BeeSwarmPlot.R
+++ b/R/do_BeeSwarmPlot.R
@@ -64,7 +64,7 @@ do_BeeSwarmPlot <- function(sample,
                             legend.text.face = "plain"){
   # Add lengthy error messages.
   withr::local_options(.new = list("warning.length" = 8170))
-  
+
   check_suggests(function_name = "do_BeeSwarmPlot")
   `%>%` <- magrittr::`%>%`
   # Check ggbeeswarm version:
@@ -169,31 +169,31 @@ do_BeeSwarmPlot <- function(sample,
                                        crayon_body(" to "),
                                        crayon_key("feature_to_rank"),
                                        crayon_body(".")))
-  
+
   colors.gradient <- compute_continuous_palette(name = ifelse(isTRUE(use_viridis), viridis.palette, sequential.palette),
                                                 use_viridis = use_viridis,
                                                 direction = ifelse(isTRUE(use_viridis), viridis.direction, sequential.direction),
                                                 enforce_symmetry = FALSE)
-  
+
   # Check group.by.
   out <- check_group_by(sample = sample,
                         group.by = group.by,
                         is.heatmap = FALSE)
   sample <- out[["sample"]]
   group.by <- out[["group.by"]]
-  
+
   # Assign legend title.
   if (is.null(legend.title)){
     legend.title <- if (isTRUE(continuous_feature)) {feature_to_rank} else {group.by}
   }
-  
-  
+
+
   dim_colnames <- check_feature(sample = sample, features = feature_to_rank, dump_reduction_names = TRUE)
   if (feature_to_rank %in% colnames(sample@meta.data)) {
     sample@meta.data$rank_me <- sample@meta.data[, feature_to_rank]
     sample@meta.data$rank <- rank(sample@meta.data$rank_me)
   } else if (feature_to_rank %in% rownames(sample)){
-    sample@meta.data$rank_me  <- .GetAssayData(sample = sample, slot = slot, assay = assay)[feature_to_rank, ]
+    sample@meta.data$rank_me  <- SeuratObject::GetAssayData(object = sample, slot = slot, assay = assay)[feature_to_rank, ]
     sample@meta.data$rank <- rank(sample@meta.data$rank_me)
   } else if (feature_to_rank %in% dim_colnames){
     for(red in Seurat::Reductions(object = sample)){
@@ -206,21 +206,21 @@ do_BeeSwarmPlot <- function(sample,
   }
   # Compute the ranking
   sample@meta.data$ranked_groups <- factor(sample@meta.data[, group.by], levels = sort(unique(sample@meta.data[, group.by])))
-  
+
   if (isTRUE(order)){
     # Get median rank by group.
-    order <- sample@meta.data %>% 
-             dplyr::select(dplyr::all_of(c("ranked_groups", "rank"))) %>% 
-             dplyr::group_by(.data$ranked_groups) %>% 
-             dplyr::summarise("median" = stats::median(.data$rank, na.rm = TRUE)) %>% 
-             dplyr::arrange(dplyr::desc(.data$median)) %>% 
-             dplyr::pull(.data$ranked_groups) %>% 
+    order <- sample@meta.data %>%
+             dplyr::select(dplyr::all_of(c("ranked_groups", "rank"))) %>%
+             dplyr::group_by(.data$ranked_groups) %>%
+             dplyr::summarise("median" = stats::median(.data$rank, na.rm = TRUE)) %>%
+             dplyr::arrange(dplyr::desc(.data$median)) %>%
+             dplyr::pull(.data$ranked_groups) %>%
              as.character()
     sample@meta.data$ranked_groups <- factor(sample@meta.data$ranked_groups, levels = rev(order))
   }
-  
+
   color_by <- ifelse(continuous_feature == TRUE, "rank_me", "ranked_groups")
-  
+
 
   # Compute the limits.
   if (isTRUE(continuous_feature)){
@@ -244,7 +244,7 @@ do_BeeSwarmPlot <- function(sample,
     sample$rank_me[sample$rank_me < min.cutoff] <- min.cutoff
     sample$rank_me[sample$rank_me > max.cutoff] <- max.cutoff
   }
-  
+
   p <- ggplot2::ggplot(sample@meta.data,
                        mapping = ggplot2::aes(x = .data[["rank"]],
                                               y = .data[["ranked_groups"]],
@@ -289,7 +289,7 @@ do_BeeSwarmPlot <- function(sample,
 
   if (continuous_feature == TRUE){
 
-    p <- p + 
+    p <- p +
          ggplot2::scale_color_gradientn(colors = colors.gradient,
                                         na.value = na.value,
                                         name = legend.title,
@@ -376,7 +376,7 @@ do_BeeSwarmPlot <- function(sample,
     p[["layers"]] <- append(base_layer, p[["layers"]])
 
   }
-  
+
 
   return(p)
 

--- a/R/do_ExpressionHeatmap.R
+++ b/R/do_ExpressionHeatmap.R
@@ -54,7 +54,7 @@ do_ExpressionHeatmap <- function(sample,
 
   # Add lengthy error messages.
   withr::local_options(.new = list("warning.length" = 8170))
-  
+
   check_suggests(function_name = "do_ExpressionHeatmap")
   # Check if the sample provided is a Seurat object.
   check_Seurat(sample = sample)
@@ -133,7 +133,7 @@ do_ExpressionHeatmap <- function(sample,
 
 
   `%>%` <- magrittr::`%>%`
-  
+
   # Generate the continuous color palette.
   if (isTRUE(enforce_symmetry)){
     colors.gradient <- compute_continuous_palette(name = diverging.palette,
@@ -194,7 +194,7 @@ do_ExpressionHeatmap <- function(sample,
     suppressMessages({
       sample$group.by <- sample@meta.data[, group]
 
-      df <- .GetAssayData(sample,
+      df <- SeuratObject::GetAssayData(sample,
                           assay = assay,
                           slot = slot)[features, , drop = FALSE] %>%
             as.matrix() %>%
@@ -241,7 +241,7 @@ do_ExpressionHeatmap <- function(sample,
       } else {
         row_order <- rownames(df.order)
       }
-      
+
     }
     if (counter == 1){
       if (length(colnames(df.order)) == 1){
@@ -252,20 +252,20 @@ do_ExpressionHeatmap <- function(sample,
         } else {
           col_order <- colnames(df.order)
         }
-        
+
       }
     }
-    
+
     if (!is.null(groups.order) & (group %in% names(groups.order))){
       groups.order.use <- groups.order[[group]]
     } else {
       groups.order.use <- row_order
     }
-    
+
     data <- df %>%
             dplyr::mutate("gene" = factor(.data$gene, levels = if (is.null(features.order)){rev(col_order)} else {features.order}),
                           "group.by" = factor(.data$group.by, levels = groups.order.use))
-    
+
     if (!is.na(min.cutoff)){
       data <- data %>%
               dplyr::mutate("mean" = ifelse(.data$mean < min.cutoff, min.cutoff, .data$mean))
@@ -316,7 +316,7 @@ do_ExpressionHeatmap <- function(sample,
     counter <- counter + 1
     data <- matrix.list[[group]][["data"]]
 
-    p <- data %>% 
+    p <- data %>%
          # nocov start
          ggplot2::ggplot(mapping = ggplot2::aes(x = if (base::isFALSE(flip)){.data$gene} else {.data$group.by},
                                                 y = if (base::isFALSE(flip)){.data$group.by} else {.data$gene},
@@ -328,7 +328,7 @@ do_ExpressionHeatmap <- function(sample,
                                    position = "top") +
          ggplot2::guides(y.sec = guide_axis_label_trans(~paste0(levels(.data$group.by))),
                          x.sec = guide_axis_label_trans(~paste0(levels(.data$gene)))) +
-         ggplot2::coord_equal() + 
+         ggplot2::coord_equal() +
          ggplot2::scale_fill_gradientn(colors = colors.gradient,
                                        na.value = na.value,
                                        name = legend.title,
@@ -460,4 +460,3 @@ do_ExpressionHeatmap <- function(sample,
 
   return(p)
 }
-

--- a/R/do_FeaturePlot.R
+++ b/R/do_FeaturePlot.R
@@ -93,7 +93,7 @@ do_FeaturePlot <- function(sample,
                            legend.text.face = "plain"){
   # Add lengthy error messages.
   withr::local_options(.new = list("warning.length" = 8170))
-  
+
   check_suggests(function_name = "do_FeaturePlot")
   # Check if the sample provided is a Seurat object.
   check_Seurat(sample = sample)
@@ -101,9 +101,9 @@ do_FeaturePlot <- function(sample,
   out <- check_and_set_assay(sample = sample, assay = assay)
   sample <- out[["sample"]]
   assay <- out[["assay"]]
-  
+
   sample <- check_Assay5(sample, assay = assay)
-  
+
   # Check the reduction.
   reduction <- check_and_set_reduction(sample = sample, reduction = reduction)
   # Check the dimensions.
@@ -293,7 +293,7 @@ do_FeaturePlot <- function(sample,
                    crayon_key("features"),
                    crayon_body(" provided. The values will be used in order and, when outside of the range, no cutoffs will be applied.")), call. = FALSE)
   }
-  
+
   if (length(max.cutoff) != length(features)){
     warning(paste0(add_warning(), crayon_body("Please provide as many values to "),
                    crayon_key("max.cutoff"),
@@ -301,7 +301,7 @@ do_FeaturePlot <- function(sample,
                    crayon_key("features"),
                    crayon_body(" provided. The values will be used in order and, when outside of the range, no cutoffs will be applied.")), call. = FALSE)
   }
-  
+
   # Generate the continuous color palette.
   if (isTRUE(enforce_symmetry)){
     colors.gradient <- compute_continuous_palette(name = diverging.palette,
@@ -314,8 +314,8 @@ do_FeaturePlot <- function(sample,
                                                   direction = ifelse(isTRUE(use_viridis), viridis.direction, sequential.direction),
                                                   enforce_symmetry = enforce_symmetry)
   }
-  
-  
+
+
   # Generate base layer.
   if (isTRUE(plot_cell_borders)){
     out <- compute_umap_layer(sample = sample,
@@ -414,7 +414,7 @@ do_FeaturePlot <- function(sample,
                                                                      limits = scale.setup$limits),
                        scale = "color")
       } else if (num_plots > 1){
-        
+
         feature.use <- features[counter]
         scale.setup <- compute_scales(sample = sample,
                                       feature = feature.use,
@@ -575,7 +575,7 @@ do_FeaturePlot <- function(sample,
         sample$dummy <- sample@meta.data[, feature]
         ## Or is a gene in the object.
       } else if (feature %in% rownames(sample)){
-        sample$dummy <- .GetAssayData(sample = sample, slot = slot, assay = assay)[feature, ]
+        sample$dummy <- SeuratObject::GetAssayData(object = sample, slot = slot, assay = assay)[feature, ]
         ## Or is a dimensional reduction component.
       } else if (feature %in% dim_colnames){
         # Iterate over each dimensional reduction in the object.
@@ -664,7 +664,7 @@ do_FeaturePlot <- function(sample,
                                                                           labels = scale.setup$labels,
                                                                           limits = scale.setup$limits),
                             scale = "color")
-        
+
         p.loop <- p.loop +
                   ggplot2::ggtitle("")
 
@@ -673,15 +673,15 @@ do_FeaturePlot <- function(sample,
           p.loop$layers <- append(base_layer_subset, p.loop$layers)
           p.loop$layers <- append(na_layer, p.loop$layers)
           p.loop$layers <- append(base_layer, p.loop$layers)
-          
+
           suppressMessages({
-            p.loop <- p.loop + 
-              ggplot2::scale_x_continuous(limits = c(min(p.loop$layers[[1]]$data$x), 
-                                                     max(p.loop$layers[[1]]$data$x))) + 
-              ggplot2::scale_y_continuous(limits = c(min(p.loop$layers[[1]]$data$y), 
+            p.loop <- p.loop +
+              ggplot2::scale_x_continuous(limits = c(min(p.loop$layers[[1]]$data$x),
+                                                     max(p.loop$layers[[1]]$data$x))) +
+              ggplot2::scale_y_continuous(limits = c(min(p.loop$layers[[1]]$data$y),
                                                      max(p.loop$layers[[1]]$data$y)))
           })
-          
+
           if (!(is.null(group.by))){
             if (isTRUE(group.by.show.dots)){
               p.loop$layers <- append(p.loop$layers, c(center_layer_2, center_layer_1))
@@ -874,15 +874,15 @@ do_FeaturePlot <- function(sample,
             p.loop$layers <- append(base_layer_subset, p.loop$layers)
             p.loop$layers <- append(na_layer, p.loop$layers)
             p.loop$layers <- append(base_layer, p.loop$layers)
-    
+
             suppressMessages({
-              p.loop <- p.loop + 
-                ggplot2::scale_x_continuous(limits = c(min(p.loop$layers[[1]]$data$x), 
-                                                       max(p.loop$layers[[1]]$data$x))) + 
-                ggplot2::scale_y_continuous(limits = c(min(p.loop$layers[[1]]$data$y), 
+              p.loop <- p.loop +
+                ggplot2::scale_x_continuous(limits = c(min(p.loop$layers[[1]]$data$x),
+                                                       max(p.loop$layers[[1]]$data$x))) +
+                ggplot2::scale_y_continuous(limits = c(min(p.loop$layers[[1]]$data$y),
                                                        max(p.loop$layers[[1]]$data$y)))
             })
-            
+
             if (!(is.null(group.by))){
               if (isTRUE(group.by.show.dots)){
                 p.loop$layers <- append(p.loop$layers, c(center_layer_2, center_layer_1))

--- a/R/do_GeyserPlot.R
+++ b/R/do_GeyserPlot.R
@@ -77,7 +77,7 @@ do_GeyserPlot <- function(sample,
                           legend.text.face = "plain"){
   # Add lengthy error messages.
   withr::local_options(.new = list("warning.length" = 8170))
-  
+
   check_suggests(function_name = "do_GeyserPlot")
   # Check if the sample provided is a Seurat object.
   check_Seurat(sample = sample)
@@ -160,9 +160,9 @@ do_GeyserPlot <- function(sample,
   check_parameters(viridis.direction, parameter_name = "viridis.direction")
   check_parameters(sequential.direction, parameter_name = "sequential.direction")
   check_parameters(diverging.direction, parameter_name = "diverging.direction")
-  
+
   `%>%` <- magrittr::`%>%`
-  
+
   # Generate the continuous color palette.
   if (isTRUE(enforce_symmetry)){
     colors.gradient <- compute_continuous_palette(name = diverging.palette,
@@ -175,7 +175,7 @@ do_GeyserPlot <- function(sample,
                                                   direction = ifelse(isTRUE(use_viridis), viridis.direction, sequential.direction),
                                                   enforce_symmetry = enforce_symmetry)
   }
-  
+
   # Check the assay.
   out <- check_and_set_assay(sample = sample, assay = assay)
   sample <- out[["sample"]]
@@ -244,7 +244,7 @@ do_GeyserPlot <- function(sample,
                         is.heatmap = FALSE)
   sample <- out[["sample"]]
   group.by <- out[["group.by"]]
-  
+
   if (is.null(colors.use)){
     colors.use <- generate_color_scale(names_use = if (is.factor(sample@meta.data[, group.by])) {
       levels(sample@meta.data[, group.by])
@@ -288,7 +288,7 @@ do_GeyserPlot <- function(sample,
               tibble::rownames_to_column(var = "cell") %>%
               tibble::as_tibble()
     } else if (isTRUE(feature %in% rownames(sample))){
-      data <- .GetAssayData(sample = sample,
+      data <- SeuratObject::GetAssayData(object = sample,
                                    assay = assay,
                                    slot = slot)[feature, , drop = FALSE] %>%
               as.matrix() %>%
@@ -408,7 +408,7 @@ do_GeyserPlot <- function(sample,
     }
     end_value <- max(abs(limits))
     if (isTRUE(scale_type == "continuous")){
-      p <- p + 
+      p <- p +
            ggplot2::scale_color_gradientn(colors = colors.gradient,
                                           na.value = na.value,
                                           name = legend.title,
@@ -416,7 +416,7 @@ do_GeyserPlot <- function(sample,
                                           labels = scale.setup$labels,
                                           limits = scale.setup$limits)
     } else if (isTRUE(scale_type == "categorical")){
-      p <- p + 
+      p <- p +
            ggplot2::scale_color_manual(values = colors.use,
                                        na.value = na.value)
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -444,7 +444,7 @@ return_dependencies <- function(){
 #' TBD
 #' }
 check_suggests <- function(function_name, passive = FALSE){
-  
+
   pkg_list <- return_dependencies()
   # The function is not in the current list of possibilities.
   if (function_name %!in% names(pkg_list)){
@@ -466,15 +466,15 @@ check_suggests <- function(function_name, passive = FALSE){
   if(sum(!pkgs) > 0){
     missing_pkgs <- names(pkgs[vapply(pkgs, function(x){base::isFALSE(x)}, FUN.VALUE = logical(1))])
     if (base::isFALSE(passive)){
-      stop(paste0(add_cross(), crayon_body("Packages "), 
-                  paste(vapply(missing_pkgs, crayon_key, FUN.VALUE = character(1)), collapse = crayon_body(", ")), 
-                  crayon_body(" must be installed to use "), 
-                  crayon_key(function_name), 
+      stop(paste0(add_cross(), crayon_body("Packages "),
+                  paste(vapply(missing_pkgs, crayon_key, FUN.VALUE = character(1)), collapse = crayon_body(", ")),
+                  crayon_body(" must be installed to use "),
+                  crayon_key(function_name),
                   crayon_body(".")), call. = FALSE)
     }
   }
-  
-  
+
+
   value <-  if(sum(pkgs) != length(pkgs)){FALSE} else {TRUE}
   if (isTRUE(passive)) {return(value)}
   # nocov end
@@ -483,9 +483,9 @@ check_suggests <- function(function_name, passive = FALSE){
 
 
 #' Generate a status report of SCpubr and its dependencies.
-#' 
+#'
 #' This function generates a summary report of the installation status of SCpubr, which packages are still missing and which functions can or can not currently be used.
-#' 
+#'
 #' @param startup \strong{\code{\link[base]{logical}}} | Whether the message should be displayed at startup, therefore, also containing welcoming messages and tips. If \strong{\code{FALSE}}, only the report itself will be printed.
 #' @param extended  \strong{\code{\link[base]{logical}}} | Whether the message should also include installed packages, current and available version, and which \strong{\code{SCpubr}} functions can be used with the currently installed packages.
 #' @return None
@@ -520,13 +520,13 @@ package_report <- function(startup = FALSE,
   } else {
     # nocov end
     tip_rule <- cli::rule(left = "General", width = nchar("General") + 6)
-    
+
     tutorials <- paste0(add_info(initial_newline = FALSE),
                         crayon_body("Have a look at extensive tutorials in "),
                         crayon_key(cli::style_hyperlink(text = "SCpubr's book",
                                                         url = "https://enblacar.github.io/SCpubr-book/")),
                         crayon_body("."))
-    
+
     cite <- paste0(add_tick(initial_newline = FALSE),
                    crayon_body("If you use "),
                    crayon_key("SCpubr"),
@@ -534,7 +534,7 @@ package_report <- function(startup = FALSE,
                    crayon_key(cli::style_hyperlink(text = "cite it accordingly",
                                                    url = "https://www.biorxiv.org/content/10.1101/2022.02.28.482303v1")),
                    crayon_body("."))
-    
+
     stars <- paste0(add_star(initial_newline = FALSE),
                     crayon_body("If the package is useful to you, consider leaving a "),
                     crayon_key("Star"),
@@ -542,7 +542,7 @@ package_report <- function(startup = FALSE,
                     crayon_key(cli::style_hyperlink(text = "GitHub repository",
                                                     url = "https://github.com/enblacar/SCpubr")),
                     crayon_body("."))
-    
+
     updates <- paste0(cli::style_bold(cli::col_blue("!")),
                       crayon_body(" Keep track of the package "),
                       crayon_key("updates"),
@@ -553,25 +553,25 @@ package_report <- function(startup = FALSE,
                       crayon_key(cli::style_hyperlink(text = "Official NEWS website",
                                                       url = "https://github.com/enblacar/SCpubr/blob/main/NEWS.md")),
                       crayon_body("."))
-    
+
     plotting <- paste0(cli::style_bold(cli::col_red(cli::symbol$heart)), " ", crayon_body("Happy plotting!"))
-    
+
     header <- cli::rule(left = paste0(crayon_body("SCpubr "),
                                       crayon_key(utils::packageVersion("SCpubr"))), line_col = "cadetblue")
-    
+
     if (isTRUE(extended)){
-      format_package_name <- function(package, 
+      format_package_name <- function(package,
                                       max_length_packages){
         length.use <- max_length_packages - nchar(package)
         package.use <- paste0(package, paste(rep(" ", length.use), collapse = ""))
         if (isTRUE(requireNamespace(package, quietly = TRUE))){
           if ((package == "ggplot2")  & (utils::packageVersion(package) < "3.4.0")){
-            name <- paste0(cli::col_yellow(cli::style_bold("!")), 
-                           " ", 
+            name <- paste0(cli::col_yellow(cli::style_bold("!")),
+                           " ",
                            cli::col_magenta(package.use))
           } else if ((package == "dplyr")  & (utils::packageVersion(package) < "1.1.0")){
-            name <- paste0(cli::col_yellow(cli::style_bold("!")), 
-                           " ", 
+            name <- paste0(cli::col_yellow(cli::style_bold("!")),
+                           " ",
                            cli::col_magenta(package.use))
           } else {
             name <- paste0(cli::col_green(cli::symbol$tick),
@@ -586,41 +586,41 @@ package_report <- function(startup = FALSE,
                         cli::col_red(package.use)))
         }
       }
-      
+
       packages <- sort(unique(unlist(return_dependencies())))
       max_length_packages <- max(vapply(packages, nchar, FUN.VALUE = numeric(1)))
-      packages_mod <- vapply(packages, function(x){format_package_name(x, 
+      packages_mod <- vapply(packages, function(x){format_package_name(x,
                                                                        max_length_packages = max_length_packages)}, FUN.VALUE = character(1))
       functions <- sort(unique(names(return_dependencies())))
-      
+
       if (rev(strsplit(as.character( as.character(utils::packageVersion("SCpubr"))), split = "\\.")[[1]])[1] >= 9000){
-        names.use <- unname(vapply(functions, function(x){if (x %in% c("do_LigandReceptorPlot", 
-                                                                       "save_Plot", 
-                                                                       "do_MetadataPlot", 
-                                                                       "do_SCExpressionHeatmap", 
-                                                                       "do_SCEnrichmentHeatmap", 
-                                                                       "do_AffinityAnalysisPlot", 
+        names.use <- unname(vapply(functions, function(x){if (x %in% c("do_LigandReceptorPlot",
+                                                                       "save_Plot",
+                                                                       "do_MetadataPlot",
+                                                                       "do_SCExpressionHeatmap",
+                                                                       "do_SCEnrichmentHeatmap",
+                                                                       "do_AffinityAnalysisPlot",
                                                                        "do_DiffusionMapPlot",
                                                                        "do_LoadingsPlot")){x <- paste0(x, cli::col_cyan(" | DEV"))} else {x}}, FUN.VALUE = character(1)))
         functions <- vapply(functions, check_suggests, passive = TRUE, FUN.VALUE = logical(1))
         names(functions) <- names.use
         # nocov start
       } else {
-        functions <- functions[!(functions %in% c("do_LigandReceptorPlot", 
-                                                  "save_Plot", 
-                                                  "do_MetadataPlot", 
-                                                  "do_SCExpressionHeatmap", 
-                                                  "do_SCEnrichmentHeatmap", 
-                                                  "do_AffinityAnalysisPlot", 
+        functions <- functions[!(functions %in% c("do_LigandReceptorPlot",
+                                                  "save_Plot",
+                                                  "do_MetadataPlot",
+                                                  "do_SCExpressionHeatmap",
+                                                  "do_SCEnrichmentHeatmap",
+                                                  "do_AffinityAnalysisPlot",
                                                   "do_DiffusionMapPlot",
                                                   "do_LoadingsPlot"))]
         functions <- vapply(functions, check_suggests, passive = TRUE, FUN.VALUE = logical(1))
       }
       # nocov end
-      
-      
+
+
       functions <- functions[names(functions) != "Essentials"]
-      
+
       max_length_functions <- max(vapply(names(functions), nchar, FUN.VALUE = numeric(1)))
       format_functions <- function(name, value, max_length){
         func_use <- ifelse(isTRUE(value), cli::col_green(cli::symbol$tick), cli::col_red(cli::symbol$cross))
@@ -629,12 +629,12 @@ package_report <- function(startup = FALSE,
                            cli::ansi_align(cli::col_red(name), max_length, align = "left"))
         paste0(func_use, " ", name_use)
       }
-      
+
       functions.use <- NULL
       for(item in names(functions)){
         functions.use <- append(functions.use, format_functions(name = item, value = functions[[item]], max_length = max_length_functions))
       }
-      
+
       counter <- 0
       print.list <- list()
       print.list.functions <- list()
@@ -642,7 +642,7 @@ package_report <- function(startup = FALSE,
       print.vector.functions <- NULL
       for(item in packages_mod){
         counter <- counter + 1
-        
+
         if (counter %% 4 != 0){
           print.vector <- append(print.vector, item)
           if (counter == length(packages)){
@@ -655,11 +655,11 @@ package_report <- function(startup = FALSE,
           print.vector <- NULL
         }
       }
-      
+
       counter <- 0
       for(item in functions.use){
         counter <- counter + 1
-        
+
         if (counter %% 3 != 0){
           print.vector.functions <- append(print.vector.functions, item)
           if (counter == length(functions.use)){
@@ -670,14 +670,14 @@ package_report <- function(startup = FALSE,
           print.list.functions[[item]] <- paste(print.vector.functions, collapse = "     ")
           print.vector.functions <- NULL
         }
-        
-        
+
+
       }
-      
+
       packages_check <- cli::rule(left = "Required packages", width = nchar("Required packages") + 6)
-      
-      packages_tip1 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)), 
-                              crayon_body(" Installed packages are denoted by a "), 
+
+      packages_tip1 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)),
+                              crayon_body(" Installed packages are denoted by a "),
                               crayon_key("tick"),
                               crayon_body(" ("),
                               cli::style_bold(cli::col_green(cli::symbol$tick)),
@@ -686,20 +686,20 @@ package_report <- function(startup = FALSE,
                               crayon_body(" ("),
                               cli::style_bold(cli::col_red(cli::symbol$cross)),
                               crayon_body(")."))
-      
-      packages_tip2 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)), 
-                              crayon_body(" Installed packages that still require an update to correctly run "), 
+
+      packages_tip2 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)),
+                              crayon_body(" Installed packages that still require an update to correctly run "),
                               crayon_key("SCpubr"),
                               crayon_body(" have an "),
                               crayon_key("exclamation mark"),
                               crayon_body(" ("),
                               cli::style_bold(cli::col_yellow("!")),
                               crayon_body(")."))
-      
-      
+
+
       functions_check <- cli::rule(left = "Available functions", width = nchar("Available functions") + 6)
-      
-      functions_tip1 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)), 
+
+      functions_tip1 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)),
                                crayon_body(" Functions tied to "),
                                crayon_key("development"),
                                crayon_body(" builds of "),
@@ -707,61 +707,61 @@ package_report <- function(startup = FALSE,
                                crayon_body(" are marked by the ("),
                                cli::style_bold(cli::col_cyan("| DEV")),
                                crayon_body(") tag."))
-      
-      functions_tip2 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)), 
+
+      functions_tip2 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)),
                                crayon_body(" You can install development builds of "),
                                crayon_key("SCpubr"),
                                crayon_body(" by following the instructions in the "),
                                crayon_key(cli::style_hyperlink(text = "Releases",
                                                                url = "https://github.com/enblacar/SCpubr/releases")),
                                crayon_body(" page."))
-      
-      functions_tip3 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)), 
-                              crayon_body(" Check the package requirements function-wise with: "), 
+
+      functions_tip3 <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)),
+                              crayon_body(" Check the package requirements function-wise with: "),
                               cli::style_italic(crayon_key('SCpubr:::return_dependencies()')))
     }
     tip_rule <- cli::rule(left = "Tips!", width = nchar("Tips!") + 6)
-    
+
     tip_message <- paste0(cli::style_bold(cli::col_cyan(cli::symbol$info)),
                           crayon_body(" To remove the white and black end from continuous palettes, use: "),
                           cli::style_italic(crayon_key('options("SCpubr.ColorPaletteEnds" = FALSE)')))
-    
-    disable_message <- paste0(cli::style_bold(cli::col_red(cli::symbol$cross)), 
-                              crayon_body(" To suppress this startup message, use: "), 
+
+    disable_message <- paste0(cli::style_bold(cli::col_red(cli::symbol$cross)),
+                              crayon_body(" To suppress this startup message, use: "),
                               cli::style_italic(crayon_key('suppressPackageStartupMessages(library(SCpubr))\n')),
-                              cli::style_bold(cli::col_red(cli::symbol$cross)), 
+                              cli::style_bold(cli::col_red(cli::symbol$cross)),
                               crayon_body(" Alternatively, you can also set the following option: "),
                               cli::style_italic(crayon_key('options("SCpubr.verbose" = FALSE)\n')),
                               crayon_body("  And then load the package normally (and faster) as: "),
                               cli::style_italic(crayon_key('library(SCpubr)')))
-    
+
     end_rule <- cli::rule(col = "cadetblue")
-    
+
     # Mount all individual messages into a big one that will be then be printed as a packageStartupMessage.
     if (isTRUE(startup)){
       if (isTRUE(extended)){
-        msg_wrap <- paste0("\n", "\n", 
+        msg_wrap <- paste0("\n", "\n",
                            header, "\n", "\n",
                            tutorials, "\n", "\n",
                            cite, "\n", "\n",
                            stars, "\n", "\n",
                            updates, "\n", "\n",
                            plotting, "\n", "\n", "\n", "\n",
-                           packages_check, "\n", "\n", 
+                           packages_check, "\n", "\n",
                            paste(print.list, collapse = "\n"), "\n", "\n",
-                           packages_tip1, "\n", 
+                           packages_tip1, "\n",
                            packages_tip2, "\n", "\n", "\n", "\n",
-                           functions_check, "\n", "\n", 
+                           functions_check, "\n", "\n",
                            paste(print.list.functions, collapse = "\n"), "\n", "\n",
-                           functions_tip1, "\n", 
-                           functions_tip2, "\n", 
+                           functions_tip1, "\n",
+                           functions_tip2, "\n",
                            functions_tip3, "\n", "\n", "\n", "\n",
                            tip_rule, "\n", "\n",
                            tip_message, "\n", "\n",
                            disable_message, "\n", "\n",
                            end_rule)
       } else {
-        msg_wrap <- paste0("\n", "\n", 
+        msg_wrap <- paste0("\n", "\n",
                            header, "\n", "\n",
                            tutorials, "\n", "\n",
                            cite, "\n", "\n",
@@ -773,27 +773,27 @@ package_report <- function(startup = FALSE,
                            disable_message, "\n", "\n",
                            end_rule)
       }
-      
+
       rlang::inform(msg_wrap, class = "packageStartupMessage")
     } else if (base::isFALSE(startup)){
       if (isTRUE(extended)){
-        msg_wrap <- paste0("\n", "\n", 
+        msg_wrap <- paste0("\n", "\n",
                            header, "\n", "\n",
-                           packages_check, "\n", "\n", 
+                           packages_check, "\n", "\n",
                            paste(print.list, collapse = "\n"), "\n", "\n",
-                           packages_tip1, "\n", 
+                           packages_tip1, "\n",
                            packages_tip2, "\n", "\n", "\n", "\n",
-                           functions_check, "\n", "\n", 
+                           functions_check, "\n", "\n",
                            paste(print.list.functions, collapse = "\n"), "\n", "\n",
-                           functions_tip1, "\n", 
-                           functions_tip2, "\n", 
+                           functions_tip1, "\n",
+                           functions_tip2, "\n",
                            functions_tip3, "\n", "\n", "\n", "\n",
                            tip_rule, "\n", "\n",
                            tip_message, "\n", "\n",
                            disable_message, "\n", "\n",
                            end_rule)
       } else {
-        msg_wrap <- paste0("\n", "\n", 
+        msg_wrap <- paste0("\n", "\n",
                            header, "\n", "\n",
                            tutorials, "\n", "\n",
                            cite, "\n", "\n",
@@ -805,7 +805,7 @@ package_report <- function(startup = FALSE,
                            disable_message, "\n", "\n",
                            end_rule)
       }
-      
+
       rlang::inform(msg_wrap)
     }
   }
@@ -876,7 +876,7 @@ check_consistency_colors_and_names <- function(sample, colors, grouping_variable
 
   # Add lengthy error messages.
   withr::local_options(.new = list("warning.length" = 8170))
-  
+
   if (is.null(grouping_variable)){
     check_values <- levels(sample)
   } else {
@@ -886,53 +886,53 @@ check_consistency_colors_and_names <- function(sample, colors, grouping_variable
       check_values <- as.character(unique(sample@meta.data[, grouping_variable]))
     }
   }
-  
+
   if (!is.null(idents.keep)){
     # Remove unwanted idents.
     check_values <- check_values[check_values %in% idents.keep]
   }
-  
+
   # Remove NAs.
   check_values <- check_values[!(is.na(check_values))]
-  
+
   # Remove values that are not in the vector.
   if (sum(names(colors) %in% check_values) == length(check_values) & length(names(colors)) > length(check_values)){
     colors <- colors[names(colors) %in% check_values]
   }
-  
+
   if (base::isFALSE(length(colors) == length(check_values)) | base::isFALSE(sum(names(colors) %in% check_values) == length(check_values))){
-    
+
     format_colors <- function(name, value, colors,  max_length){
-      
+
       if (name %in% names(colors)){
         name <- paste(c(name, crayon_body(" | "), cli::col_cyan(paste0(colors[[name]]))), collapse = "")
       }
-      
+
       func_use <- ifelse(isTRUE(value), cli::col_green(cli::symbol$tick), cli::col_red(cli::symbol$cross))
       name_use <- ifelse(isTRUE(value),
                          cli::ansi_align(crayon_key(name), max_length, align = "left"),
                          cli::ansi_align(cli::col_red(name), max_length, align = "left"))
       paste0(func_use, " ", name_use)
     }
-      
+
       color_check <- vapply(check_values, function(x){ifelse(x %in% names(colors), TRUE, FALSE)}, FUN.VALUE = logical(1))
-      
+
       max_length <- max(vapply(check_values, nchar, FUN.VALUE = numeric(1)))
       max_length_colors <- max(vapply(unname(colors), nchar, FUN.VALUE = numeric(1)))
       length.use <- max_length + 3 + max_length_colors
-      
-      
+
+
       colors.print <- NULL
       for(item in sort(names(color_check))){
         colors.print <- append(colors.print, format_colors(name = item, colors = colors, value = color_check[[item]], max_length = length.use))
       }
-      
-      
+
+
     msg <- paste0("\n", "\n",
-                  add_cross(), 
+                  add_cross(),
                   crayon_body("The "),
                   crayon_key("number"),
-                  crayon_body(" or "), 
+                  crayon_body(" or "),
                   crayon_key("names"),
                   crayon_body(" of the provided "),
                   crayon_key("colors"),
@@ -940,9 +940,9 @@ check_consistency_colors_and_names <- function(sample, colors, grouping_variable
                   crayon_key("number of unique values"),
                   crayon_body(" in "),
                   crayon_key("group.by"),
-                  crayon_body(" (which defaults to "), 
+                  crayon_body(" (which defaults to "),
                   cli::style_italic(crayon_key("Seurat::Idents(sample)")),
-                  crayon_body(" if "), 
+                  crayon_body(" if "),
                   crayon_key("NULL"),
                   crayon_body(")."),
                   "\n",
@@ -953,17 +953,17 @@ check_consistency_colors_and_names <- function(sample, colors, grouping_variable
                   crayon_key("named vector"),
                   crayon_body(" where the names are the "),
                   crayon_key("unique values"),
-                  crayon_body(" to which you then assign the "), 
+                  crayon_body(" to which you then assign the "),
                   crayon_key("colors"),
-                  crayon_body(" to."), 
+                  crayon_body(" to."),
                   "\n", "\n",
                   add_warning(),
                   crayon_body("Example: "),
                   cli::style_italic(crayon_key('colors.use = c("A" = "red", "B" = "blue")')),
                   "\n",
                   "\n", "\n",
-                  crayon_body(cli::rule(left = paste0(crayon_key("Values"), crayon_body(" with an "), cli::col_cyan("assigned color")), width = nchar("Values with an assigned color") + 6)), 
-                  "\n", "\n", 
+                  crayon_body(cli::rule(left = paste0(crayon_key("Values"), crayon_body(" with an "), cli::col_cyan("assigned color")), width = nchar("Values with an assigned color") + 6)),
+                  "\n", "\n",
                   paste(colors.print, collapse = "\n"), "\n", "\n")
     stop(msg, call. = FALSE)
   }
@@ -1026,7 +1026,7 @@ compute_scale_limits <- function(sample, feature, assay = NULL, reduction = NULL
   }
 
   if (feature %in% rownames(sample)){
-    data.check <- .GetAssayData(sample,
+    data.check <- SeuratObject::GetAssayData(sample,
                                        assay = assay,
                                        slot = slot)[feature, ]
     scale.begin <- min(data.check, na.rm = TRUE)
@@ -1197,7 +1197,7 @@ compute_scales <- function(sample,
       value.use <- max(c(low_end, high_end))
       limits <- c(1 - value.use, 1 + value.use)
     }
-    
+
   }
 
   breaks <- labeling::extended(dmin = limits[1],
@@ -1218,9 +1218,9 @@ compute_scales <- function(sample,
       labels[length(labels)] <- paste0(as.character(expression("\u2265")), " ", max.cutoff)
     }
   }
-  
+
   # Fix for the one value limit.
-  
+
   if(limits[[1]] == limits[[2]]){
     breaks <- limits[[1]]
     labels <- as.character(limits[[1]])
@@ -1320,7 +1320,7 @@ check_feature <- function(sample, features, permissive = FALSE, dump_reduction_n
       not_found_features <- append(not_found_features, feature)
     }
   }
-  
+
   # Return the error logs if there were features not found.
   if (length(not_found_features) > 0){
     if (isTRUE(permissive)){
@@ -1859,7 +1859,7 @@ compute_enrichment_scores <- function(sample,
       # nocov end
     }
   }
-  
+
   if (flavor == "AUCell"){
     if (!requireNamespace("AUCell", quietly = TRUE)) {
       # nocov start
@@ -1950,7 +1950,7 @@ compute_enrichment_scores <- function(sample,
     if (is.null(slot)){
       slot <- "data"
     }
-    scores <- AUCell::AUCell_run(exprMat = .GetAssayData(sample, assay = assay, slot = slot),
+    scores <- AUCell::AUCell_run(exprMat = SeuratObject::GetAssayData(sample, assay = assay, slot = slot),
                                  geneSets = input_gene_list)
     scores <- scores@assays@data$AUC %>%
               as.matrix() %>%
@@ -1971,12 +1971,12 @@ compute_enrichment_scores <- function(sample,
                                          by = "cell") %>%
                         tibble::column_to_rownames(var = "cell")
   }
-  
+
   # Compute a 0-1 normalization.
   for (name in names(input_gene_list)){
     sample@meta.data[, paste0(name, "_scaled")] <- zero_one_norm(sample@meta.data[, name])
   }
-  
+
   return(sample)
 }
 
@@ -2096,7 +2096,7 @@ get_data_column <- function(sample,
                       tibble::rownames_to_column(var = "cell") %>%
                       dplyr::rename("feature" = dplyr::all_of(c(feature)))
   } else if (isTRUE(feature %in% rownames(sample))){
-    feature_column <- .GetAssayData(sample = sample,
+    feature_column <- SeuratObject::GetAssayData(object = sample,
                                     assay = assay,
                                     slot = slot)[feature, , drop = FALSE] %>%
                       as.matrix() %>%
@@ -3064,7 +3064,7 @@ handle_axis <- function(flip,
       strip.text <- ggplot2::element_blank()
       legend.position <- "none"
     }
-    
+
     if (counter == 1){
       axis.ticks.x.bottom <- ggplot2::element_line(color = "black")
       axis.ticks.x.top <- ggplot2::element_blank()
@@ -3087,7 +3087,7 @@ handle_axis <- function(flip,
                                                   hjust = 0.5)
         axis.title.x.bottom <- ggplot2::element_blank()
       }
-      
+
       axis.title.y.left <- ggplot2::element_text(face = axis.title.face, color = "black",
                                                  angle = 90,
                                                  hjust = 0.5,
@@ -3112,13 +3112,13 @@ handle_axis <- function(flip,
         axis.title.x.top <- ggplot2::element_blank()
         axis.title.x.bottom <- ggplot2::element_blank()
       }
-      
+
       axis.title.y.left <- ggplot2::element_text(face = axis.title.face, color = "black",
                                                  angle = 90,
                                                  hjust = 0.5,
                                                  vjust = 0.5)
       axis.title.y.right <- ggplot2::element_blank()
-      
+
     }
   } else {
     # Strips and legend.
@@ -3138,8 +3138,8 @@ handle_axis <- function(flip,
       strip.text <- ggplot2::element_blank()
       legend.position <- "none"
     }
-    
-    
+
+
     if (counter == 1){
       axis.ticks.x.bottom <- ggplot2::element_line(color = "black")
       axis.ticks.x.top <- ggplot2::element_blank()
@@ -3174,7 +3174,7 @@ handle_axis <- function(flip,
                                                    hjust = 0.5)
         axis.title.y.right <- ggplot2::element_blank()
       }
-      
+
     } else {
       axis.ticks.x.bottom <- ggplot2::element_line(color = "black")
       axis.ticks.x.top <- ggplot2::element_blank()
@@ -3205,7 +3205,7 @@ handle_axis <- function(flip,
       }
     }
   }
-  
+
   out_list <- list("axis.ticks.x.top" = axis.ticks.x.top,
                    "axis.ticks.x.bottom" = axis.ticks.x.bottom,
                    "axis.ticks.y.left" = axis.ticks.y.left,
@@ -3223,7 +3223,7 @@ handle_axis <- function(flip,
                    "strip.text" = strip.text,
                    "legend.position" = legend.position)
   return(out_list)
-  
+
 }
 
 #' Generate a list of colors that will be used for metadata plots.
@@ -3235,7 +3235,7 @@ handle_axis <- function(flip,
 #' TBD
 #' }
 get_SCpubr_colors <- function(){
-  
+
   colors <- c("#457b9d",
               "#b5838d",
               "#d4a276",
@@ -3259,51 +3259,6 @@ get_SCpubr_colors <- function(){
   return(colors)
 }
 
-# This needs to be modified when Seurat V5 is on CRAN.
-
-#' Retrieve assay data depending on the version of SeuratObject
-#'
-#' @param sample Seurat object.
-#' @param assay Assay name.
-#' @param slot slot name.
-#'
-#' @return The assay data.
-#' @noRd
-#' @examples
-#' \donttest{
-#' TBD
-#' }
-.GetAssayData <- function(sample,
-                         assay,
-                         slot){
-  
-  # Check version of SeuratObject.
-  version <- utils::packageVersion("SeuratObject")
-  # nocov start
-  if (version > "4.1.3"){
-    if (slot == "counts"){
-      data <- sample@assays[[assay]]$counts
-    } else if (slot == "data"){
-      data <- sample@assays[[assay]]$data
-    } else if (slot == "scale.data"){
-      data <- sample@assays[[assay]]$scale.data
-    }
-    
-    # Uncomment once the version is on CRAN.
-    # data <- SeuratObject::LayerData(object = sample,
-    #                                 assay = assay,
-    #                                 layer = slot)
-  
-    # nocov end
-  } else {
-    data <- SeuratObject::GetAssayData(object = sample,
-                                       assay = assay,
-                                       slot = slot)
-  }
-  return(data)
-}
-
-
 #' Set assay data depending on the version of SeuratObject
 #'
 #' @param sample Seurat object.
@@ -3321,7 +3276,7 @@ get_SCpubr_colors <- function(){
                           assay,
                           slot,
                           data){
-  
+
   # Check version of SeuratObject.
   version <- utils::packageVersion("SeuratObject")
   # nocov start
@@ -3333,12 +3288,12 @@ get_SCpubr_colors <- function(){
     } else if (slot == "scale.data"){
       sample@assays[[assay]]$scale.data <- data
     }
-    
+
     # Uncomment once the version is on CRAN.
     # SeuratObject::LayerData(object = sample,
     #                         assay = assay,
     #                         layer = slot) <- data
-    
+
     # nocov end
   } else {
     sample <- SeuratObject::SetAssayData(object = sample,
@@ -3364,9 +3319,9 @@ get_SCpubr_colors <- function(){
 check_group_by <- function(sample,
                            group.by,
                            is.heatmap){
-  
+
   group.by.return <- NULL
-  
+
   if (is.null(group.by)){
     assertthat::assert_that(!("Groups" %in% colnames(sample@meta.data)),
                             msg = paste0(add_cross(), crayon_body("Please, make sure you provide a value for "),
@@ -3377,7 +3332,7 @@ check_group_by <- function(sample,
     sample@meta.data[, "Groups"] <- sample@active.ident
     group.by <- "Groups"
   }
-  
+
   for (group in group.by){
     assertthat::assert_that(group %in% colnames(sample@meta.data),
                             msg = paste0(add_cross(), crayon_body("The value provided to "),
@@ -3385,7 +3340,7 @@ check_group_by <- function(sample,
                                          crayon_body(" is not part of the Seurat object "),
                                          crayon_key("meta.data"),
                                          crayon_body(".")))
-    
+
     assertthat::assert_that(class(sample@meta.data[, group]) %in% c("character", "factor"),
                             msg = paste0(add_cross(), crayon_body("The value provided to"),
                                          crayon_key(paste0("group.by (", group, " | defaults to Seurat::Idents(sample) if NULL)")),
@@ -3396,7 +3351,7 @@ check_group_by <- function(sample,
                                          crayon_body(" column in the sample"),
                                          crayon_key("metadata of the Seurat object"),
                                          crayon_body(".")))
-    
+
     if (isTRUE(is.heatmap)){
       assertthat::assert_that(sum(is.na(sample@meta.data[, group])) == 0,
                               msg = paste0(add_warning(), crayon_body("Found "),
@@ -3481,7 +3436,7 @@ compute_continuous_palette <- function(name = "YlGnBu",
         }
       }
     }
-    
+
   } else {
     if (direction == 1){
       colors <- RColorBrewer::brewer.pal(n = 11, name = name)
@@ -3538,4 +3493,3 @@ range_norm <- function(x, a, b){
   y <- (b - a) * ((x - (min(x, na.rm = TRUE))) / (max(x, na.rm = TRUE) - min(x, na.rm = TRUE))) + a
   return(y)
 }
-


### PR DESCRIPTION
Replace custom data accessors with Seurat-provided accessors (`GetAssayData()`. `GetAssayData()` will continue to work in v5 on both v3 and v5 assays and will not throw deprecation warnings or errors in downstream packages until well into the v5 lifecyle. Should we decide to end usage of `GetAssayData()`, we will let you and other downstream packages know well ahead of time

resolves #38 