### PR TITLE
Fix for do_VolcanoPlot when order_tags_by = "both"

### DIFF
--- a/R/do_VolcanoPlot.R
+++ b/R/do_VolcanoPlot.R
@@ -173,7 +173,7 @@ do_VolcanoPlot <- function(sample,
 
   if (isTRUE(add_gene_tags)){
     if (order_tags_by == "both"){
-      data.label <- genes %>%
+      data.label <- de_genes %>%
                     dplyr::mutate("abs_avg_log2FC" = abs(.data$avg_log2FC)) %>% 
                     dplyr::arrange(dplyr::desc(.data$log_p),
                                    dplyr::desc(.data$abs_avg_log2FC)) %>%

--- a/R/do_VolcanoPlot.R
+++ b/R/do_VolcanoPlot.R
@@ -178,7 +178,7 @@ do_VolcanoPlot <- function(sample,
                     dplyr::arrange(dplyr::desc(.data$log_p),
                                    dplyr::desc(.data$abs_avg_log2FC)) %>%
                     as.data.frame() %>%
-                    utils::head(number.tags * 2)
+                    utils::head(n_genes * 2)
     } else if (order_tags_by == "pvalue"){
       data.up <- data %>%
                  dplyr::filter(.data$avg_log2FC > 0) %>%

--- a/R/do_VolcanoPlot.R
+++ b/R/do_VolcanoPlot.R
@@ -192,6 +192,8 @@ do_VolcanoPlot <- function(sample,
                    dplyr::arrange(dplyr::desc(.data$log_p)) %>%
                    as.data.frame() %>%
                    utils::head(n_genes)
+      
+      data.label <- dplyr::bind_rows(data.up, data.down)
     } else if (order_tags_by == "logfc"){
       data.up <- data %>%
                  dplyr::arrange(dplyr::desc(.data$avg_log2FC)) %>%
@@ -202,6 +204,8 @@ do_VolcanoPlot <- function(sample,
                    dplyr::arrange(.data$avg_log2FC) %>%
                    as.data.frame() %>%
                    utils::head(n_genes)
+
+      data.label <- dplyr::bind_rows(data.up, data.down)
     }
 
     if (add_tag_side == "positive") {

--- a/R/do_VolcanoPlot.R
+++ b/R/do_VolcanoPlot.R
@@ -173,7 +173,7 @@ do_VolcanoPlot <- function(sample,
 
   if (isTRUE(add_gene_tags)){
     if (order_tags_by == "both"){
-      data.label <- de_genes %>%
+      data.label <- data %>%
                     dplyr::mutate("abs_avg_log2FC" = abs(.data$avg_log2FC)) %>% 
                     dplyr::arrange(dplyr::desc(.data$log_p),
                                    dplyr::desc(.data$abs_avg_log2FC)) %>%


### PR DESCRIPTION
Resolves #63. Changed object references when creating 'data.label' for the "both" condition. Added calls to bind_rows for the "pvalue" and "logfc" conditions so that 'data.label' is created.